### PR TITLE
Allow combo keys to be held down

### DIFF
--- a/left_hand/generator.R
+++ b/left_hand/generator.R
@@ -84,11 +84,11 @@ enum custom_keycodes {
   LOCK_SHIFT,\n"
 
 for(i in 1:dim(data)[1]){
-key <- toString(data[i,1])
-layer <- unlist(strsplit(data[i,2],","))
-for(j in 1:length(layer)){
-str = paste(str,"A_",layer[j],"_",key,",\n",sep="")
-}
+  key <- toString(data[i,1])
+  layer <- unlist(strsplit(data[i,2],","))
+  for(j in 1:length(layer)){
+    str = paste(str,"A_",layer[j],"_",key,",\n",sep="")
+  }
 }
 
 
@@ -100,21 +100,21 @@ str = paste(str,"A_",layer[j],"_",key,",\n",sep="")
 data <- read.csv("artsey_keycodes.csv")
 
 for(i in 1:dim(data)[1]){
-key <- toString(data[i,1])
-layer <- toString(data[i,2])
-tap <- toString(data[i,3])
-hold <- toString(data[i,4])
-if((tap==""|tap=="NA")){
-str = paste(str,"A_",layer,"_",key,",\n",sep="")
-}
-else if((hold==""|hold=="NA")){
-str = paste(str,"A_",layer,"_",key," = ",sep="")
-str = paste(str,tap,",\n",sep="")
-}
-else{
-str = paste(str,"A_",layer,"_",key," = ",sep="")
-str = paste(str,"LT(",hold,",",tap,"),\n",sep="")
-}
+  key <- toString(data[i,1])
+  layer <- toString(data[i,2])
+  tap <- toString(data[i,3])
+  hold <- toString(data[i,4])
+  if((tap==""|tap=="NA")){
+    str = paste(str,"A_",layer,"_",key,",\n",sep="")
+  }
+  else if((hold==""|hold=="NA")){
+    str = paste(str,"A_",layer,"_",key," = ",sep="")
+    str = paste(str,tap,",\n",sep="")
+  }
+  else{
+    str = paste(str,"A_",layer,"_",key," = ",sep="")
+    str = paste(str,"LT(",hold,",",tap,"),\n",sep="")
+  }
 }
 
 
@@ -130,21 +130,21 @@ data <- read.csv("artsey_combos.csv")
 fileConn <- file("artsey_basic.def")
 str = ""
 for(i in 1:dim(data)[1]){
-layer <- unlist(strsplit(data[i,2],","))
-action <- data[i,3]
-unlisted <- unlist(strsplit(data[i,1],""))
-if(length(unlisted)>1){
-for(j in 1:length(layer)){
-str = paste(str,"COMB(",data[i,1],layer[j],"COMB,",sep="")
-str = paste(str,"A_",layer[j],"_",data[i,1],",",sep="")
-str = paste(str,"A_",layer[j],"_",unlisted[1],sep="")
-for(k in 2:length(unlisted)){
-str = paste(str,",A_",layer[j],"_",unlisted[k],sep="")
-}
-str = paste(str,")\n",sep="")
-}
-}
-
+  layer <- unlist(strsplit(data[i,2],","))
+  action <- data[i,3]
+  unlisted <- unlist(strsplit(data[i,1],""))
+  if(length(unlisted)>1){
+    for(j in 1:length(layer)){
+      str = paste(str,"COMB(",data[i,1],layer[j],"COMB,",sep="")
+      str = paste(str,"A_",layer[j],"_",data[i,1],",",sep="")
+      str = paste(str,"A_",layer[j],"_",unlisted[1],sep="")
+      for(k in 2:length(unlisted)){
+        str = paste(str,",A_",layer[j],"_",unlisted[k],sep="")
+      }
+      str = paste(str,")\n",sep="")
+    }
+  }
+  
 }
 
 

--- a/left_hand/generator.R
+++ b/left_hand/generator.R
@@ -31,14 +31,23 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 for(i in 1:dim(data)[1]){
 	key <- toString(data[i,1])
 	layer <- unlist(strsplit(data[i,2],","))
-	action <- toString(data[i,3])
-	if(!(action==""|action=="NA")){
+	actionDown <- toString(data[i,3])
+	actionUp <- ""
+	if (grepl("tap_code", actionDown, fixed = TRUE)){
+	  actionUp <- sub("tap_code", "unregister_code", actionDown)
+	  actionDown <- sub("tap_code", "register_code", actionDown)
+	}
+	if(!(actionDown==""|actionDown=="NA")){
 		for(j in 1:length(layer)){
 		str = paste(str,"case A_",layer[j],"_",key,":\n",sep="")
 		str = paste(str,"if(record->event.pressed) {\n",sep="")
-		str = paste(str,action,";\n",sep="")
+		str = paste(str,actionDown,";\n",sep="")
 		str = paste(str,"}\n",sep="")
-		str = paste(str,"else {}\n",sep="")
+		str = paste(str,"else {\n",sep="")
+		if(!(actionUp==""|actionUp=="NA")){
+		  str = paste(str,actionUp,";\n",sep="")
+		}
+		str = paste(str,"}\n",sep="")
 		str =paste(str,"break;\n")
 	}
 	}

--- a/left_hand/macros.c
+++ b/left_hand/macros.c
@@ -24,519 +24,662 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     break;
 case A_BASE_AR:
 if(record->event.pressed) {
-tap_code(KC_F);
+register_code(KC_F);
 }
-else {}
+else {
+unregister_code(KC_F);
+}
  break;
 case A_BASE_AS:
 if(record->event.pressed) {
-tap_code(KC_W);
+register_code(KC_W);
 }
-else {}
+else {
+unregister_code(KC_W);
+}
  break;
 case A_BASE_RT:
 if(record->event.pressed) {
-tap_code(KC_G);
+register_code(KC_G);
 }
-else {}
+else {
+unregister_code(KC_G);
+}
  break;
 case A_BASE_RS:
 if(record->event.pressed) {
-tap_code(KC_V);
+register_code(KC_V);
 }
-else {}
+else {
+unregister_code(KC_V);
+}
  break;
 case A_BASE_TS:
 if(record->event.pressed) {
-tap_code(KC_J);
+register_code(KC_J);
 }
-else {}
+else {
+unregister_code(KC_J);
+}
  break;
 case A_BASE_ART:
 if(record->event.pressed) {
-tap_code(KC_D);
+register_code(KC_D);
 }
-else {}
+else {
+unregister_code(KC_D);
+}
  break;
 case A_BASE_ATS:
 if(record->event.pressed) {
-tap_code(KC_Q);
+register_code(KC_Q);
 }
-else {}
+else {
+unregister_code(KC_Q);
+}
  break;
 case A_BASE_RTS:
 if(record->event.pressed) {
-tap_code(KC_X);
+register_code(KC_X);
 }
-else {}
+else {
+unregister_code(KC_X);
+}
  break;
 case A_BASE_EY:
 if(record->event.pressed) {
-tap_code(KC_C);
+register_code(KC_C);
 }
-else {}
+else {
+unregister_code(KC_C);
+}
  break;
 case A_BASE_EI:
 if(record->event.pressed) {
-tap_code(KC_H);
+register_code(KC_H);
 }
-else {}
+else {
+unregister_code(KC_H);
+}
  break;
 case A_BASE_EO:
 if(record->event.pressed) {
-tap_code(KC_B);
+register_code(KC_B);
 }
-else {}
+else {
+unregister_code(KC_B);
+}
  break;
 case A_BASE_YI:
 if(record->event.pressed) {
-tap_code(KC_U);
+register_code(KC_U);
 }
-else {}
+else {
+unregister_code(KC_U);
+}
  break;
 case A_BASE_YO:
 if(record->event.pressed) {
-tap_code(KC_K);
+register_code(KC_K);
 }
-else {}
+else {
+unregister_code(KC_K);
+}
  break;
 case A_BASE_IO:
 if(record->event.pressed) {
-tap_code(KC_N);
+register_code(KC_N);
 }
-else {}
+else {
+unregister_code(KC_N);
+}
  break;
 case A_BASE_EYI:
 if(record->event.pressed) {
-tap_code(KC_L);
+register_code(KC_L);
 }
-else {}
+else {
+unregister_code(KC_L);
+}
  break;
 case A_BASE_EIO:
 if(record->event.pressed) {
-tap_code(KC_P);
+register_code(KC_P);
 }
-else {}
+else {
+unregister_code(KC_P);
+}
  break;
 case A_BASE_YIO:
 if(record->event.pressed) {
-tap_code(KC_M);
+register_code(KC_M);
 }
-else {}
+else {
+unregister_code(KC_M);
+}
  break;
 case A_BASE_ARTS:
 if(record->event.pressed) {
-tap_code(KC_Z);
+register_code(KC_Z);
 }
-else {}
+else {
+unregister_code(KC_Z);
+}
  break;
 case A_BASE_AYI:
 if(record->event.pressed) {
-tap_code(KC_QUOT);
+register_code(KC_QUOT);
 }
-else {}
+else {
+unregister_code(KC_QUOT);
+}
  break;
 case A_BASE_AY:
 if(record->event.pressed) {
-tap_code(KC_COMMA);
+register_code(KC_COMMA);
 }
-else {}
+else {
+unregister_code(KC_COMMA);
+}
  break;
 case A_BASE_AI:
 if(record->event.pressed) {
-tap_code(KC_DOT);
+register_code(KC_DOT);
 }
-else {}
+else {
+unregister_code(KC_DOT);
+}
  break;
 case A_BASE_TI:
 if(record->event.pressed) {
 SEND_STRING("!");
 }
-else {}
+else {
+}
  break;
 case A_BASE_AO:
 if(record->event.pressed) {
-tap_code(KC_SLSH);
+register_code(KC_SLSH);
 }
-else {}
+else {
+unregister_code(KC_SLSH);
+}
  break;
 case A_BASE_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_NUM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_SYM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_BRAC_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_NAV_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_MOU_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_CUSTOM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_BASE_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_NUM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_SYM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_NAV_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_MOU_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_BASE_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_NUM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_SYM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_BRAC_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_NAV_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_MOU_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_CUSTOM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_BASE_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_NUM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_SYM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_BRAC_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_NAV_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_MOU_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_CUSTOM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_BASE_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_BASE_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_BASE_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_BASE_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_NUM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_SYM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_BRAC_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_NAV_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_MOU_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_CUSTOM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_BASE_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_NUM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_SYM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_BRAC_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_NAV_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_MOU_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_CUSTOM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_BASE_RY:
 if(record->event.pressed) {
@@ -549,7 +692,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NUM_RY:
 if(record->event.pressed) {
@@ -562,7 +706,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_SYM_RY:
 if(record->event.pressed) {
@@ -575,7 +720,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_BRAC_RY:
 if(record->event.pressed) {
@@ -588,7 +734,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NAV_RY:
 if(record->event.pressed) {
@@ -601,7 +748,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_MOU_RY:
 if(record->event.pressed) {
@@ -614,7 +762,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_RY:
 if(record->event.pressed) {
@@ -627,133 +776,160 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NUM_AR:
 if(record->event.pressed) {
-tap_code(KC_7);
+register_code(KC_7);
 }
-else {}
+else {
+unregister_code(KC_7);
+}
  break;
 case A_NUM_RT:
 if(record->event.pressed) {
-tap_code(KC_8);
+register_code(KC_8);
 }
-else {}
+else {
+unregister_code(KC_8);
+}
  break;
 case A_NUM_EY:
 if(record->event.pressed) {
-tap_code(KC_9);
+register_code(KC_9);
 }
-else {}
+else {
+unregister_code(KC_9);
+}
  break;
 case A_NUM_YI:
 if(record->event.pressed) {
-tap_code(KC_0);
+register_code(KC_0);
 }
-else {}
+else {
+unregister_code(KC_0);
+}
  break;
 case A_BASE_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_NUM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_SYM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_BRAC_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_NAV_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_MOU_ATY:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_NUM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_SYM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_BRAC_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_MOU_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_NAV_REI:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_SO:
 if(record->event.pressed) {
 layer_move(_A_CUSTOM);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SO:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_AYIO:
 if(record->event.pressed) {
-tap_code(KC_CAPS);
+register_code(KC_CAPS);
 }
-else {}
+else {
+unregister_code(KC_CAPS);
+}
  break;
  
   }

--- a/right_hand/generator.R
+++ b/right_hand/generator.R
@@ -29,19 +29,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     break;
 "
 for(i in 1:dim(data)[1]){
-  key <- toString(data[i,1])
-  layer <- unlist(strsplit(data[i,2],","))
-  action <- toString(data[i,3])
-  if(!(action==""|action=="NA")){
-    for(j in 1:length(layer)){
-      str = paste(str,"case A_",layer[j],"_",key,":\n",sep="")
-      str = paste(str,"if(record->event.pressed) {\n",sep="")
-      str = paste(str,action,";\n",sep="")
-      str = paste(str,"}\n",sep="")
-      str = paste(str,"else {}\n",sep="")
-      str =paste(str,"break;\n")
-    }
-  }
+	key <- toString(data[i,1])
+	layer <- unlist(strsplit(data[i,2],","))
+	actionDown <- toString(data[i,3])
+	actionUp <- ""
+	if (grepl("tap_code", actionDown, fixed = TRUE)){
+	  actionUp <- sub("tap_code", "unregister_code", actionDown)
+	  actionDown <- sub("tap_code", "register_code", actionDown)
+	}
+	if(!(actionDown==""|actionDown=="NA")){
+		for(j in 1:length(layer)){
+		str = paste(str,"case A_",layer[j],"_",key,":\n",sep="")
+		str = paste(str,"if(record->event.pressed) {\n",sep="")
+		str = paste(str,actionDown,";\n",sep="")
+		str = paste(str,"}\n",sep="")
+		str = paste(str,"else {\n",sep="")
+		if(!(actionUp==""|actionUp=="NA")){
+		  str = paste(str,actionUp,";\n",sep="")
+		}
+		str = paste(str,"}\n",sep="")
+		str =paste(str,"break;\n")
+	}
+	}
 }
 
 str =paste(str,"

--- a/right_hand/macros.c
+++ b/right_hand/macros.c
@@ -24,519 +24,662 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     break;
 case A_BASE_AR:
 if(record->event.pressed) {
-tap_code(KC_F);
+register_code(KC_F);
 }
-else {}
+else {
+unregister_code(KC_F);
+}
  break;
 case A_BASE_AS:
 if(record->event.pressed) {
-tap_code(KC_W);
+register_code(KC_W);
 }
-else {}
+else {
+unregister_code(KC_W);
+}
  break;
 case A_BASE_RT:
 if(record->event.pressed) {
-tap_code(KC_G);
+register_code(KC_G);
 }
-else {}
+else {
+unregister_code(KC_G);
+}
  break;
 case A_BASE_RS:
 if(record->event.pressed) {
-tap_code(KC_V);
+register_code(KC_V);
 }
-else {}
+else {
+unregister_code(KC_V);
+}
  break;
 case A_BASE_TS:
 if(record->event.pressed) {
-tap_code(KC_J);
+register_code(KC_J);
 }
-else {}
+else {
+unregister_code(KC_J);
+}
  break;
 case A_BASE_ART:
 if(record->event.pressed) {
-tap_code(KC_D);
+register_code(KC_D);
 }
-else {}
+else {
+unregister_code(KC_D);
+}
  break;
 case A_BASE_ATS:
 if(record->event.pressed) {
-tap_code(KC_Q);
+register_code(KC_Q);
 }
-else {}
+else {
+unregister_code(KC_Q);
+}
  break;
 case A_BASE_RTS:
 if(record->event.pressed) {
-tap_code(KC_X);
+register_code(KC_X);
 }
-else {}
+else {
+unregister_code(KC_X);
+}
  break;
 case A_BASE_EY:
 if(record->event.pressed) {
-tap_code(KC_C);
+register_code(KC_C);
 }
-else {}
+else {
+unregister_code(KC_C);
+}
  break;
 case A_BASE_EI:
 if(record->event.pressed) {
-tap_code(KC_H);
+register_code(KC_H);
 }
-else {}
+else {
+unregister_code(KC_H);
+}
  break;
 case A_BASE_EO:
 if(record->event.pressed) {
-tap_code(KC_B);
+register_code(KC_B);
 }
-else {}
+else {
+unregister_code(KC_B);
+}
  break;
 case A_BASE_YI:
 if(record->event.pressed) {
-tap_code(KC_U);
+register_code(KC_U);
 }
-else {}
+else {
+unregister_code(KC_U);
+}
  break;
 case A_BASE_YO:
 if(record->event.pressed) {
-tap_code(KC_K);
+register_code(KC_K);
 }
-else {}
+else {
+unregister_code(KC_K);
+}
  break;
 case A_BASE_IO:
 if(record->event.pressed) {
-tap_code(KC_N);
+register_code(KC_N);
 }
-else {}
+else {
+unregister_code(KC_N);
+}
  break;
 case A_BASE_EYI:
 if(record->event.pressed) {
-tap_code(KC_L);
+register_code(KC_L);
 }
-else {}
+else {
+unregister_code(KC_L);
+}
  break;
 case A_BASE_EIO:
 if(record->event.pressed) {
-tap_code(KC_P);
+register_code(KC_P);
 }
-else {}
+else {
+unregister_code(KC_P);
+}
  break;
 case A_BASE_YIO:
 if(record->event.pressed) {
-tap_code(KC_M);
+register_code(KC_M);
 }
-else {}
+else {
+unregister_code(KC_M);
+}
  break;
 case A_BASE_ARTS:
 if(record->event.pressed) {
-tap_code(KC_Z);
+register_code(KC_Z);
 }
-else {}
+else {
+unregister_code(KC_Z);
+}
  break;
 case A_BASE_AYI:
 if(record->event.pressed) {
-tap_code(KC_QUOT);
+register_code(KC_QUOT);
 }
-else {}
+else {
+unregister_code(KC_QUOT);
+}
  break;
 case A_BASE_AY:
 if(record->event.pressed) {
-tap_code(KC_COMMA);
+register_code(KC_COMMA);
 }
-else {}
+else {
+unregister_code(KC_COMMA);
+}
  break;
 case A_BASE_AI:
 if(record->event.pressed) {
-tap_code(KC_DOT);
+register_code(KC_DOT);
 }
-else {}
+else {
+unregister_code(KC_DOT);
+}
  break;
 case A_BASE_TI:
 if(record->event.pressed) {
 SEND_STRING("!");
 }
-else {}
+else {
+}
  break;
 case A_BASE_AO:
 if(record->event.pressed) {
-tap_code(KC_SLSH);
+register_code(KC_SLSH);
 }
-else {}
+else {
+unregister_code(KC_SLSH);
+}
  break;
 case A_BASE_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_NUM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_SYM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_BRAC_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_NAV_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_MOU_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_CUSTOM_RE:
 if(record->event.pressed) {
-tap_code(KC_BSPC);
+register_code(KC_BSPC);
 }
-else {}
+else {
+unregister_code(KC_BSPC);
+}
  break;
 case A_BASE_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_NUM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_SYM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_NAV_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_MOU_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_RTSE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LSHIFT));
 }
-else {}
+else {
+}
  break;
 case A_BASE_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_NUM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_SYM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_BRAC_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_NAV_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_MOU_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_CUSTOM_AE:
 if(record->event.pressed) {
-tap_code(KC_ENTER);
+register_code(KC_ENTER);
 }
-else {}
+else {
+unregister_code(KC_ENTER);
+}
  break;
 case A_BASE_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_NUM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_SYM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_BRAC_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_NAV_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_MOU_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_CUSTOM_ARO:
 if(record->event.pressed) {
-tap_code(KC_ESC);
+register_code(KC_ESC);
 }
-else {}
+else {
+unregister_code(KC_ESC);
+}
  break;
 case A_BASE_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SE:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LCTRL));
 }
-else {}
+else {
+}
  break;
 case A_BASE_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SY:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LGUI));
 }
-else {}
+else {
+}
  break;
 case A_BASE_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_NUM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_SYM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_BRAC_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_NAV_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_MOU_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SI:
 if(record->event.pressed) {
 add_oneshot_mods(MOD_BIT(KC_LALT));
 }
-else {}
+else {
+}
  break;
 case A_BASE_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_NUM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_SYM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_BRAC_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_NAV_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_MOU_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_CUSTOM_EYIO:
 if(record->event.pressed) {
-tap_code(KC_SPACE);
+register_code(KC_SPACE);
 }
-else {}
+else {
+unregister_code(KC_SPACE);
+}
  break;
 case A_BASE_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_NUM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_SYM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_BRAC_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_NAV_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_MOU_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_CUSTOM_ARTO:
 if(record->event.pressed) {
-tap_code(KC_TAB);
+register_code(KC_TAB);
 }
-else {}
+else {
+unregister_code(KC_TAB);
+}
  break;
 case A_BASE_RY:
 if(record->event.pressed) {
@@ -549,7 +692,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NUM_RY:
 if(record->event.pressed) {
@@ -562,7 +706,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_SYM_RY:
 if(record->event.pressed) {
@@ -575,7 +720,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_BRAC_RY:
 if(record->event.pressed) {
@@ -588,7 +734,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NAV_RY:
 if(record->event.pressed) {
@@ -601,7 +748,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_MOU_RY:
 if(record->event.pressed) {
@@ -614,7 +762,8 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_RY:
 if(record->event.pressed) {
@@ -627,133 +776,160 @@ if(record->event.pressed) {
           unregister_code(KC_LSFT);
         };
 }
-else {}
+else {
+}
  break;
 case A_NUM_AR:
 if(record->event.pressed) {
-tap_code(KC_7);
+register_code(KC_7);
 }
-else {}
+else {
+unregister_code(KC_7);
+}
  break;
 case A_NUM_RT:
 if(record->event.pressed) {
-tap_code(KC_8);
+register_code(KC_8);
 }
-else {}
+else {
+unregister_code(KC_8);
+}
  break;
 case A_NUM_EY:
 if(record->event.pressed) {
-tap_code(KC_9);
+register_code(KC_9);
 }
-else {}
+else {
+unregister_code(KC_9);
+}
  break;
 case A_NUM_YI:
 if(record->event.pressed) {
-tap_code(KC_0);
+register_code(KC_0);
 }
-else {}
+else {
+unregister_code(KC_0);
+}
  break;
 case A_BASE_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_NUM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_SYM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_BRAC_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_NAV_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_ATY:
 if(record->event.pressed) {
 layer_move(_A_MOU);
 }
-else {}
+else {
+}
  break;
 case A_MOU_ATY:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_NUM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_SYM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_BRAC_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_MOU_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_REI:
 if(record->event.pressed) {
 layer_move(_A_NAV);
 }
-else {}
+else {
+}
  break;
 case A_NAV_REI:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_SO:
 if(record->event.pressed) {
 layer_move(_A_CUSTOM);
 }
-else {}
+else {
+}
  break;
 case A_CUSTOM_SO:
 if(record->event.pressed) {
 layer_move(_A_BASE);
 }
-else {}
+else {
+}
  break;
 case A_BASE_AYIO:
 if(record->event.pressed) {
-tap_code(KC_CAPS);
+register_code(KC_CAPS);
 }
-else {}
+else {
+unregister_code(KC_CAPS);
+}
  break;
  
   }


### PR DESCRIPTION
This changes the behavior of combo keys to be the same as the base layer, ie when held down the key will repeat. Currently, combo keys will only send a tap no matter how long they are held.

I've modified both generator.R scripts to transform combo tap_code into register / unregister on key press / release. The source CSV files remain unchanged.

You could instead explicitly have key down / up actions in the CSV file but it does read nicer as a single tap_code(KC_X) instead of many repeated register_code(KC_X) / unregister_code(KC_X)

_I've never used R before so please suggest alternative string comparison functions if there is something more appropriate_

Have tested this on a lefty paintbrush, works correctly with combos on the base layer along with the number layer.